### PR TITLE
chore(release): build the admin UI during the release, from a clean directory

### DIFF
--- a/.releaseconfig.json
+++ b/.releaseconfig.json
@@ -1,6 +1,6 @@
 {
 	"plugins": ["iobroker", "license", "manual-review"],
 	"exec": {
-		"before_commit": "npm run build"
+		"before_commit": "npm run build:all"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "translate": "translate-adapter",
     "release": "release-script",
     "npm": "npm i && cd src-admin && npm i",
+    "prebuild:admin": "clean-dir ./src-admin/build && clean-dir ./admin/custom",
     "build:admin": "cd src-admin && npm run build",
     "build:all": "npm run build && npm run build:admin",
     "lint:admin": "cd src-admin && npm run lint",


### PR DESCRIPTION
The release script ran `npm run build` before the release commit, which only builds the adapter - not the admin UI. The generated admin files are shipped though (`files` covers `admin/**`), so keeping them up to date was pure discipline: any src-admin change that forgot to commit the rebuilt bundle would ship an outdated UI.

- .releaseconfig.json now runs `build:all`, which covers both.
- `prebuild:admin` wipes `src-admin/build` and `admin/custom` first. Without it the bundles are not reproducible: building on top of a previous result alternates between two outputs (measured - build 1 and 3 identical, build 2 different), so every release would produce a bundle diff even with no source change. From an empty directory the build is reproducible and matches the committed bundles exactly.